### PR TITLE
Fix cast processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 *~
-
+.DS_Store
 *.swp
 stack.yaml.lock
 result

--- a/examples/cast-bot.ldgv
+++ b/examples/cast-bot.ldgv
@@ -1,0 +1,2 @@
+type Bool : ~un = {'T, 'F}
+val f1 = case ('T : Bool => _|_) of {'T : 22 , 'F : "a" }

--- a/examples/cast-collide.ldgv
+++ b/examples/cast-collide.ldgv
@@ -1,0 +1,2 @@
+type Bool : ~un = {'T, 'F}
+val f1 =  case (( 'T : Bool => *) : * =>  Int ) { 'T : 5 , 'F : 'T }

--- a/examples/cast-fail.ldgv
+++ b/examples/cast-fail.ldgv
@@ -1,0 +1,12 @@
+type Bool : ~un = {'T, 'F}
+
+val not : (b: Bool) -> Bool
+val not   (b: Bool) = (case b {'T: 'F, 'F: 'T})
+
+val f1 = case ('T : Bool => Int) of {'T : 22 , 'F : "a" }
+
+val f2 = ('T : {'T, 'F, 'N} => Bool)
+
+val f3 = fn (x: *)
+          fn (y: case (x: {'T, 'F, 'N} => Bool) {'T: Int, 'F: { 'T , 'F } })
+	       case (x: * => Bool) {'T: 17+y, 'F: not y}

--- a/examples/cast-fail.ldgv
+++ b/examples/cast-fail.ldgv
@@ -3,10 +3,10 @@ type Bool : ~un = {'T, 'F}
 val not : (b: Bool) -> Bool
 val not   (b: Bool) = (case b {'T: 'F, 'F: 'T})
 
-val f1 = case ('T : Bool => Int) of {'T : 22 , 'F : "a" }
+-- val f1 = case ('T : Bool => Int) of {'T : 22 , 'F : "a" } -- fails
 
 val f2 = ('T : {'T, 'F, 'N} => Bool)
 
 val f3 = fn (x: *)
-          fn (y: case (x: {'T, 'F, 'N} => Bool) {'T: Int, 'F: { 'T , 'F } })
+          fn (y: case (x: * => Bool) {'T: Int, 'F: { 'T , 'F } })
 	       case (x: * => Bool) {'T: 17+y, 'F: not y}

--- a/examples/gradualtest.ldgv
+++ b/examples/gradualtest.ldgv
@@ -7,7 +7,8 @@ val f (x : *)
       ( y : case ( x : * => Bool) of { 'T : Int , 'F : { 'T , 'F } } )
 = (case (x : * => Bool) of { 'T : 42 + y , 'F : (case y of {'T : "a" , 'F : 4 }) })
 
-val f' = f 'T 1
+-- fails unless gradual
+--val f' = f 'T 1
 
 val f'' = f ( 'F : Bool => *) ('T)
 

--- a/examples/gradualtest.ldgv
+++ b/examples/gradualtest.ldgv
@@ -1,0 +1,28 @@
+type Bool : ~un = {'T, 'F}
+
+val not : (b: Bool) -> Bool
+val not   (b: Bool) = (case b {'T: 'F, 'F: 'T})
+
+val f (x : *)
+      ( y : case ( x : * => Bool) of { 'T : Int , 'F : { 'T , 'F } } )
+= (case (x : * => Bool) of { 'T : 42 + y , 'F : (case y of {'T : "a" , 'F : 4 }) })
+
+val f' = f 'T 1
+
+val f'' = f ( 'F : Bool => *) ('T)
+
+val f''' = f ( 'T : { 'T } => *) 1
+
+val f1 = case (( 'T : Bool => *) : * => Bool) of {'T : 22 , 'F : "a" }
+
+--val f2 = case (( 'T : Int => *) : * => Bool) of {'T : 22 , 'F : "a" } fails 
+
+--val f3 = case (( 'T : Bool => *) : * => Int) of {'T : 22 , 'F : "a" } fails
+
+--val f4 = case (( 'T : Bool => Int) : * => Bool) of {'T : 22 , 'F : "a" } fails
+
+val f5 = fn (x: *)
+          fn (y: case (x: * => Bool) {'T: Int, 'F: { 'T , 'F } })
+	       case (x: * => Bool) {'T: 17+y, 'F: not y}
+
+-- val f5' = f5 (1: Int => *) (2: Int => *)  fails

--- a/ldgv.cabal
+++ b/ldgv.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -23,7 +23,11 @@ extra-doc-files:
     examples/case-singleton.ldgv
     examples/casesub.ldgv
     examples/casetest.ldgv
+    examples/cast-bot.ldgv
+    examples/cast-collide.ldgv
+    examples/cast-fail.ldgv
     examples/depsum.ldgv
+    examples/gradualtest.ldgv
     examples/natsum.ldgv
     examples/natsum2-new.ldgv
     examples/natsum2-rec.ldgv

--- a/src/TCSubtyping.hs
+++ b/src/TCSubtyping.hs
@@ -143,7 +143,7 @@ valueEquivM' tenv = \case
     in  do results <- foldM f mEqn lInd
            case results of
              Just (Cast (e'@(Lit (LLab lab))) _ _, _) -> do
-               _ <- subtype tenv (TLab [lab]) tout
+               _ <- subtypeMark ("VE1 " ++ pshow e) tenv (TLab [lab]) tout
                kentry <- kindLookup tn
                pure $ Just (e', cdualof b $ keType kentry)
              _ ->
@@ -155,7 +155,7 @@ valueEquivM' tenv = \case
     in  do results <- foldM f mEqn lInd
            case results of
              Just (Cast (e'@(Lit (LLab lab))) _ _, _) -> do
-               _ <- subtype tenv (TLab [lab]) tout
+               _ <- subtypeMark ("VE2 " ++ pshow e) tenv (TLab [lab]) tout
                kentry <- kindLookup tn
                pure $ Just (e', cdualof b $ keType kentry)
              _ ->
@@ -167,22 +167,25 @@ valueEquivM' tenv = \case
     in  do results <- foldM f mEqn lInd
            case results of
              Just (Cast (e'@(Lit (LLab lab))) _ _, _) -> do
-               _ <- subtype tenv (TLab [lab]) tout
+               _ <- subtypeMark ("VE3 " ++ pshow e) tenv (TLab [lab]) tout
                pure $ Just (e', tout)
              _ ->
               pure $ Nothing
-  (Cast e tname tout) ->
-    case e of 
+  e0@(Cast e tname tout) ->
+    case e of
        (Cast (e'@(Lit (LLab lab))) tname' tout')  -> do 
-          _ <- eqvtype' tenv tout' tname
-          _ <- subtype tenv (TLab [lab]) tout
-          _ <- subtype tenv tname' tout
+          -- _ <- eqvtype' tenv tout' tname
+          _ <- subtypeMark ("VE4 " ++ pshow e0) tenv (TLab [lab]) tout
+          -- _ <- subtype tenv tname' tout
           pure $ Just (e', tout)
-       (Lit (LLab lab)) -> do 
-          _ <- subtype tenv (TLab [lab]) tout
-          _ <- subtype tenv tname tout
-          pure $ Just (e, tout) 
-       _ -> pure $ Nothing 
+       (Lit (LLab lab)) -> do
+          _ <- subtypeMark ("VE5 " ++ pshow e0) tenv (TLab [lab]) tout
+          -- _ <- subtype tenv tname tout
+          pure $ Just (e, tout)
+       _ -> pure $ Nothing
+    `TC.catchError` \ _ -> do
+      D.traceOnlyM "valueEquiv" "failed"
+      pure $ Nothing
   e@_ -> pure $ Nothing
 
 valueEquivM :: TEnv -> Exp -> TCM (Maybe (Exp, Type))
@@ -262,6 +265,8 @@ tyBound te = \case
   TSingle x -> do
     (_, tyx) <- varlookup x te
     tyBound te tyx
+  TBot ->
+    pure TBot
   _ ->
     pure TDyn
 
@@ -271,21 +276,40 @@ unfold :: TEnv -> Type -> TCM Type
 unfold tenv (TName b tn) = do
   kentry <- kindLookup tn
   unfold tenv $ cdualof b $ keType kentry -- was: return $
-unfold tenv (TCase val cases)
-  | Just (Lit (LLab lll), TLab _) <- valueEquiv tenv val = do
+unfold tenv t0@(TCase val cases) = do
+  ve <- valueEquivM tenv val
+  case ve of
+    Just (Lit (LLab lll), TLab _) -> do
       ty <- lablookup lll cases
       unfold tenv ty
-unfold tenv t0@(TCase (Cast val@(Var x) tvar tval) cases) = do
+    _ -> do
+      unfold' tenv t0
+
+unfold tenv (TNatRec e1 tz1 tv1 ts1)
+  | Just (v, TNat) <- valueEquiv tenv e1 =
+      case v of
+        Lit (LNat 0) ->
+          unfold tenv tz1
+        Lit (LNat n) | n > 0 ->
+          unfold tenv (tsubst tv1 (TNatRec (Lit $ LNat (n-1)) tz1 tv1 ts1) ts1)
+        Succ var ->
+          unfold tenv (tsubst tv1 (TNatRec var tz1 tv1 ts1) ts1)
+        _ ->
+          TC.mfail "eqvtype: type mismatch"
+unfold tenv ty =
+  return ty
+
+unfold' tenv t0@(TCase (Cast val@(Var x) tvar tval) cases) = do
   let caselabels = map fst cases
-  -- only consider reachable cases 
+  -- only consider reachable cases
   tvalUnfolded <- unfold tenv tval
   let checkedLabels = case tvalUnfolded of
         TLab labels -> filter (`elem` labels) caselabels -- sequence in caselabels must be preserved
         _ -> caselabels
   -- check if cast is type correct
   (_, tyx) <- varlookup x tenv
-  kx <- subtype tenv tyx tvar
-  kl <- subtype tenv tval (TLab caselabels)
+  kx <- subtypeMark "unfold-x" tenv tyx tvar
+  kl <- subtypeMark "unfold-l" tenv tval (TLab caselabels)
   results <- mapM (\(lll, tyl) -> unfold (("*unfold*", (Many, TEqn val (Cast (Lit $ LLab lll) (TLab caselabels) tvar) tvar)) : tenv) tyl) (filter ((`elem` checkedLabels) . fst) cases)
 
   case commonGrounds results of
@@ -312,17 +336,7 @@ unfold tenv t0@(TCase (Cast val@(Var x) tvar tval) cases) = do
     _ ->
       TC.mfail "unfold dynamic: type mismatch"
 
-unfold tenv t0@(TCase (Cast val t1 t2) cases) = do
-  valEquiv <- valueEquivM tenv val 
-  _ <- subtype tenv t1 t2    -- check if cast is type correct  
-  case valEquiv of 
-    Just (Lit (LLab lll), tout) -> do 
-      _ <- eqvtype' tenv tout t1    -- check if cast is type correct 
-      ty <- lablookup lll cases
-      unfold tenv ty  
-    Nothing -> TC.mfail "cast mismatch"
-
-unfold tenv t0@(TCase val@(Var x) cases) = do
+unfold' tenv t0@(TCase val@(Var x) cases) = do
   let caselabels = map fst cases
   tyx <- varlookupUnfolding x tenv
   results <- case tyx of
@@ -360,19 +374,14 @@ unfold tenv t0@(TCase val@(Var x) cases) = do
     _ ->
       TC.mfail "unfold dynamic: type mismatch"
 
-unfold tenv (TNatRec e1 tz1 tv1 ts1)
-  | Just (v, TNat) <- valueEquiv tenv e1 =
-      case v of
-        Lit (LNat 0) ->
-          unfold tenv tz1
-        Lit (LNat n) | n > 0 ->
-          unfold tenv (tsubst tv1 (TNatRec (Lit $ LNat (n-1)) tz1 tv1 ts1) ts1)
-        Succ var ->
-          unfold tenv (tsubst tv1 (TNatRec var tz1 tv1 ts1) ts1)
-        _ ->
-          TC.mfail "eqvtype: type mismatch"
-unfold tenv ty =
-  return ty
+unfold' tenv t0@(TCase e cases) = do
+  valEquiv <- valueEquivM tenv e
+  case valEquiv of
+    Just (Lit (LLab lll), tout) -> do
+      -- _ <- eqvtype' tenv tout t1    -- check if cast is type correct
+      ty <- lablookup lll cases
+      unfold tenv ty
+    Nothing -> TC.mfail ("cast mismatch-1 " ++ pshow t0)
 
 data GHead = GDyn | GLab | GUnit | GInt | GNat | GDouble | GString | GFun Multiplicity | GPair | GSend | GRecv
   deriving (Eq)
@@ -567,6 +576,8 @@ complete xs [] ty =
 
 -- subtyping
 subtype' :: TEnv -> Type -> Type -> TCM Kind
+subtype' tenv TBot ty2 =
+  return Kunit
 subtype' tenv ty1 ty2@(TVar b tv) = do
   kentry <- kindLookup tv
   D.traceOnlyM "Subtype constraint" (pshow ty1 ++ " <: " ++ pshow ty2)
@@ -577,8 +588,13 @@ subtype' tenv ty1@(TVar b tv) ty2 = do
   D.traceOnlyM "Subtype constraint" (pshow ty1 ++ " <: " ++ pshow ty2)
   TC.tell [ty1 :<: ty2]
   return (keKind kentry)
-subtype' tenv TDyn _ = return Kunit
-subtype' tenv _ TDyn = return Kunit
+subtype' tenv TDyn TDyn = return Kunit
+subtype' tenv TDyn t = do
+  failUnlessGradual ("subtype: * <: " ++ pshow t)
+  return Kunit
+subtype' tenv t TDyn = do
+  failUnlessGradual ("subtype: " ++ pshow t ++ " <: *")
+  return Kunit
 subtype' tenv TUnit TUnit = return Kunit
 subtype' tenv TInt TInt = return Kunit
 subtype' tenv TDouble TDouble = return Kunit
@@ -789,6 +805,11 @@ subtype'caser tenv ty1 (TCase val@(Var x) cases) =
 subtype'caser tenv ty1 ty2 =
   TC.mfail ("Subtyping (case right) fails to establish " ++ pshow ty1 ++ " <: " ++ pshow ty2)
 
+subtypeMark :: String -> TEnv -> Type -> Type -> TCM Kind
+subtypeMark mark tenv t1 t2 = do
+  D.traceOnlyM "subtype" mark
+  subtype tenv t1 t2
+
 subtype :: TEnv -> Type -> Type -> TCM Kind
 subtype tenv t1 t2 = do
   D.traceOnlyM "subtype" ("Entering " ++ pshow tenv ++ " (" ++ pshow t1 ++ ") (" ++ pshow t2 ++ ")")
@@ -805,6 +826,7 @@ tcase e tye sts = TCase e sts
 
 -- same beast, but checks branch types for equivalence
 tcaseM :: TEnv -> Exp -> Type -> [(String, Type)] -> TCM Type
+tcaseM te e tye [] = return TBot
 tcaseM te e tye allcases@((_, t) : cases) =
   ap (return (\t -> D.trace ("tcaseM returns " ++ pshow t) t)) $
   D.trace ("tcaseM " ++ pshow (te, e, allcases)) $ (do

--- a/src/TCXMonad.hs
+++ b/src/TCXMonad.hs
@@ -1,6 +1,6 @@
 module TCXMonad (
   M, runM,
-  mget, mstate, mupdate, mfail, tell, listen, censor
+  mget, mstate, mupdate, mfail, tell, listen, censor, catchError
   ) where
 
 import Control.Monad.Reader

--- a/src/Typechecker.hs
+++ b/src/Typechecker.hs
@@ -56,7 +56,8 @@ exec tcOptions seendIds tenv kenv (cmd:cmds) = execCmd cmd
       traceM ("--- type checking: " ++ f ++ " ---")
       let buildFunction c = foldr (\(m, v, ty) -> c m v ty)
           buildty = buildFunction G.TFun
-          e' = buildFunction G.Lam e binds
+          eAlpha = G.alphaConversion e
+          e' = buildFunction G.Lam eAlpha binds
       (tenv', cmds') <- case (Map.lookup f seendIds, mty) of
         (Nothing, Nothing) -> do
           -- Synthesize the type of the definition.


### PR DESCRIPTION
src/TCSubtyping.hs, Zeile 170, valueequivM'
-------------------------------------------

e@_ -> pure $ Nothing eingeführt, da 
val f (x : *)
      ( y : case ( x : * => Bool) of { 'T : Int , 'F : { 'T , 'F } } )
= (case (x : * => Bool) of { 'T : 42 + y , 'F : (case y of {'T : "a" , 'F : 4 }) })
val f' = f ( 'F ) ('T) 

fehlschlägt, 

da 
src\TCSubtyping.hs:(139,21)-(158,28): Non-exhaustive patterns in case

src/TCTyping.hs, Zeile 54, kisynth
----------------------------------
Ich habe es so abgeändert, dass nur der branch, der auch im case identifier steht ausgewertet wird. 

Ansonsten schlägt das Beispiel (gradualtest.ldgv): 
val f (x : *)
      ( y : case ( x : * => Bool) of { 'T : Int , 'F : { 'T , 'F } } )
= (case (x : * => Bool) of { 'T : 42 + y , 'F : (case y of {'T : "a" , 'F : 4 }) })

val f' = f ( 'T ) (1)

mit der Fehlermeldung

(*kis*, (_, {{( 'T : * => Bool ) == 'F : {'T, 'F}}}))
Subtyping fails to establish Int <: {'T, 'F} 

fehl, da hier auch der 'F - branch ausgewertet wird. 


src/TCSubtyping.hs, Zeile 158, valueequivM'
-------------------------------------------
(Cast e tname tout): 
Falls expression e keine Variable ist sondern ein Cast, sollen Cast-reduzierungen (cast-collide, cast-fail,..) vorgenommen werden. Ansonsten werden in keiner Funktion verschachtelte Casts abgefragt.
Daher schlägt der simple Test  :
val f1 = case (( 'T : Bool => *) : * => Bool) of {'T : 22 , 'F : "a" } (gradualtest.ldgv) fehl.


src/TCSubtyping.hs, Zeile 289, unfold
-------------------------------------
Sobald eine Application und im Case Header ein Cast mit einem Literal vorkommt, wie bei dem Test (gradualtest.ldgv): 
val f (x : *)
      ( y : case ( x : * => Bool) of { 'T : Int , 'F : { 'T , 'F } } )
= (case (x : * => Bool) of { 'T : 42 + y , 'F : (case y of {'T : "a" , 'F : 4 }) })
val f' = f ( 'F ) ('T) 

wird der Typ nicht richtig aufgelöst, sodass für f' der Typ 
( ( case ( ( 'F : Bool => * ) : * => Bool ) {'T:Int, 'F:case 'T {'T:String, 'F:Nat}} herauskommt.

Daher wurde ein weiterer Fall eingeführt, der auch den Fall, dass der Case Header ein Cast eines Literals ist, abfängt.


src/TCTyping.hs, Zeile 275, tysynth
-----------------------------------

Da in valueequivM' in Cast-Fällen (V: A => B) lediglich der Ausgangstyp B zurückgegeben wird, muss in dem Fall, dass der Cast im Case Header vorkommt, nicht unbedingt 
der aufgelöste Label-Typ für B herauskommen, sondern es kann auch der unaufgelöste Typ TName Bool herauskommen. 